### PR TITLE
log -> logrus

### DIFF
--- a/vsphere/config.go
+++ b/vsphere/config.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/url"
 	"os"

--- a/vsphere/config_test.go
+++ b/vsphere/config_test.go
@@ -4,7 +4,7 @@
 package vsphere
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"reflect"
 	"strconv"

--- a/vsphere/data_source_vsphere_dynamic.go
+++ b/vsphere/data_source_vsphere_dynamic.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/data_source_vsphere_host_pci_device.go
+++ b/vsphere/data_source_vsphere_host_pci_device.go
@@ -4,7 +4,7 @@
 package vsphere
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strconv"
 

--- a/vsphere/data_source_vsphere_license.go
+++ b/vsphere/data_source_vsphere_license.go
@@ -4,7 +4,7 @@
 package vsphere
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/govmomi/license"

--- a/vsphere/data_source_vsphere_role.go
+++ b/vsphere/data_source_vsphere_role.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 

--- a/vsphere/data_source_vsphere_virtual_machine.go
+++ b/vsphere/data_source_vsphere_virtual_machine.go
@@ -5,7 +5,7 @@ package vsphere
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/vsphere/distributed_virtual_port_setting_structure.go
+++ b/vsphere/distributed_virtual_port_setting_structure.go
@@ -4,7 +4,7 @@
 package vsphere
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/vsphere/distributed_virtual_switch_structure.go
+++ b/vsphere/distributed_virtual_switch_structure.go
@@ -5,7 +5,7 @@ package vsphere
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/internal/helper/clustercomputeresource/cluster_compute_resource_helper.go
+++ b/vsphere/internal/helper/clustercomputeresource/cluster_compute_resource_helper.go
@@ -6,7 +6,7 @@ package clustercomputeresource
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/vsphere/internal/helper/computeresource/compute_resource_helper.go
+++ b/vsphere/internal/helper/computeresource/compute_resource_helper.go
@@ -6,7 +6,7 @@ package computeresource
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem"

--- a/vsphere/internal/helper/contentlibrary/content_library_helper.go
+++ b/vsphere/internal/helper/contentlibrary/content_library_helper.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/url"
 	"os"

--- a/vsphere/internal/helper/datastore/datastore_helper.go
+++ b/vsphere/internal/helper/datastore/datastore_helper.go
@@ -6,7 +6,7 @@ package datastore
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"path"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder"

--- a/vsphere/internal/helper/envbrowse/environment_browser_helper.go
+++ b/vsphere/internal/helper/envbrowse/environment_browser_helper.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25"

--- a/vsphere/internal/helper/folder/folder_helper.go
+++ b/vsphere/internal/helper/folder/folder_helper.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"path"
 	"strings"
 

--- a/vsphere/internal/helper/hostsystem/host_system_helper.go
+++ b/vsphere/internal/helper/hostsystem/host_system_helper.go
@@ -6,7 +6,7 @@ package hostsystem
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider"

--- a/vsphere/internal/helper/ovfdeploy/ovf_helper.go
+++ b/vsphere/internal/helper/ovfdeploy/ovf_helper.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"os"
 	"strings"

--- a/vsphere/internal/helper/resourcepool/resource_pool_helper.go
+++ b/vsphere/internal/helper/resourcepool/resource_pool_helper.go
@@ -6,7 +6,7 @@ package resourcepool
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/computeresource"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider"

--- a/vsphere/internal/helper/spbm/spbm_helper.go
+++ b/vsphere/internal/helper/spbm/spbm_helper.go
@@ -6,7 +6,7 @@ package spbm
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi"

--- a/vsphere/internal/helper/storagepod/storage_pod_helper.go
+++ b/vsphere/internal/helper/storagepod/storage_pod_helper.go
@@ -6,7 +6,7 @@ package storagepod
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore"

--- a/vsphere/internal/helper/utils/entityIdToManagedObjectId.go
+++ b/vsphere/internal/helper/utils/entityIdToManagedObjectId.go
@@ -5,7 +5,7 @@ package utils
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine"
 	"github.com/vmware/govmomi"

--- a/vsphere/internal/helper/vappcontainer/vappcontainer_helper.go
+++ b/vsphere/internal/helper/vappcontainer/vappcontainer_helper.go
@@ -5,7 +5,7 @@ package vappcontainer
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider"
 	"github.com/vmware/govmomi"

--- a/vsphere/internal/helper/virtualdisk/virtual_disk_helper.go
+++ b/vsphere/internal/helper/virtualdisk/virtual_disk_helper.go
@@ -6,7 +6,7 @@ package virtualdisk
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"path"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider"

--- a/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
+++ b/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"strconv"
 	"strings"

--- a/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
@@ -5,7 +5,7 @@ package virtualdevice
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 

--- a/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
@@ -6,7 +6,7 @@ package virtualdevice
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math"
 	"reflect"
 	"strconv"

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -6,7 +6,7 @@ package virtualdevice
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math"
 	"path"
 	"reflect"

--- a/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
@@ -6,7 +6,7 @@ package virtualdevice
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"sort"
 	"strings"

--- a/vsphere/internal/vmworkflow/virtual_machine_clone_subresource.go
+++ b/vsphere/internal/vmworkflow/virtual_machine_clone_subresource.go
@@ -5,7 +5,7 @@ package vmworkflow
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/vsphere/resource_vsphere_compute_cluster.go
+++ b/vsphere/resource_vsphere_compute_cluster.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sort"
 	"strings"
 

--- a/vsphere/resource_vsphere_compute_cluster_host_group.go
+++ b/vsphere/resource_vsphere_compute_cluster_host_group.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_compute_cluster_vm_affinity_rule.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_affinity_rule.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 

--- a/vsphere/resource_vsphere_compute_cluster_vm_anti_affinity_rule.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_anti_affinity_rule.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 

--- a/vsphere/resource_vsphere_compute_cluster_vm_dependency_rule.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_dependency_rule.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 

--- a/vsphere/resource_vsphere_compute_cluster_vm_group.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_group.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_compute_cluster_vm_host_rule.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_host_rule.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 

--- a/vsphere/resource_vsphere_content_library.go
+++ b/vsphere/resource_vsphere_content_library.go
@@ -4,7 +4,7 @@
 package vsphere
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_content_library_item.go
+++ b/vsphere/resource_vsphere_content_library_item.go
@@ -5,7 +5,7 @@ package vsphere
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_datacenter.go
+++ b/vsphere/resource_vsphere_datacenter.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/vsphere/resource_vsphere_datastore_cluster.go
+++ b/vsphere/resource_vsphere_datastore_cluster.go
@@ -5,7 +5,7 @@ package vsphere
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/vsphere/resource_vsphere_datastore_cluster_vm_anti_affinity_rule.go
+++ b/vsphere/resource_vsphere_datastore_cluster_vm_anti_affinity_rule.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 

--- a/vsphere/resource_vsphere_dpm_host_override.go
+++ b/vsphere/resource_vsphere_dpm_host_override.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_drs_vm_override.go
+++ b/vsphere/resource_vsphere_drs_vm_override.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_entity_permissions.go
+++ b/vsphere/resource_vsphere_entity_permissions.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vsphere/resource_vsphere_file.go
+++ b/vsphere/resource_vsphere_file.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"path"
 	"strings"
 	"time"

--- a/vsphere/resource_vsphere_folder_migrate.go
+++ b/vsphere/resource_vsphere_folder_migrate.go
@@ -4,7 +4,7 @@
 package vsphere
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder"

--- a/vsphere/resource_vsphere_ha_vm_override.go
+++ b/vsphere/resource_vsphere_ha_vm_override.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_host.go
+++ b/vsphere/resource_vsphere_host.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider"
 

--- a/vsphere/resource_vsphere_license.go
+++ b/vsphere/resource_vsphere_license.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"context"
 

--- a/vsphere/resource_vsphere_resource_pool.go
+++ b/vsphere/resource_vsphere_resource_pool.go
@@ -5,7 +5,7 @@ package vsphere
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/vsphere/resource_vsphere_role.go
+++ b/vsphere/resource_vsphere_role.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sort"
 	"strconv"
 	"strings"

--- a/vsphere/resource_vsphere_storage_drs_vm_override.go
+++ b/vsphere/resource_vsphere_storage_drs_vm_override.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_tag.go
+++ b/vsphere/resource_vsphere_tag.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_tag_category.go
+++ b/vsphere/resource_vsphere_tag_category.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_vapp_container.go
+++ b/vsphere/resource_vsphere_vapp_container.go
@@ -5,7 +5,7 @@ package vsphere
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_vapp_entity.go
+++ b/vsphere/resource_vsphere_vapp_entity.go
@@ -5,7 +5,7 @@ package vsphere
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_virtual_disk.go
+++ b/vsphere/resource_vsphere_virtual_disk.go
@@ -5,7 +5,7 @@ package vsphere
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"errors"

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"os"
 	"strings"

--- a/vsphere/resource_vsphere_virtual_machine_migrate.go
+++ b/vsphere/resource_vsphere_virtual_machine_migrate.go
@@ -5,7 +5,7 @@ package vsphere
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strconv"
 	"strings"

--- a/vsphere/resource_vsphere_virtual_machine_snapshot.go
+++ b/vsphere/resource_vsphere_virtual_machine_snapshot.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_vm_storage_policy.go
+++ b/vsphere/resource_vsphere_vm_storage_policy.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_vnic.go
+++ b/vsphere/resource_vsphere_vnic.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 

--- a/vsphere/tags_helper.go
+++ b/vsphere/tags_helper.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -5,7 +5,7 @@ package vsphere
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 
 	"github.com/mitchellh/copystructure"

--- a/vsphere/virtual_machine_guest_structure.go
+++ b/vsphere/virtual_machine_guest_structure.go
@@ -4,7 +4,7 @@
 package vsphere
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"sort"
 	"strings"


### PR DESCRIPTION
Use logrus for logging instead of standard log library

[_Created by Sourcegraph batch change `admin/use-logrus-in-terraform-providers`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/use-logrus-in-terraform-providers)